### PR TITLE
Updated AndroidManifest.xml to trust user installed CA certificate

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" />
 
     <application
+        android:networkSecurityConfig="@xml/network_security_config"
         android:name=".PowerTunnelApplication"
         android:allowBackup="false"
         android:banner="@mipmap/tv_banner"


### PR DESCRIPTION
As you may know later Android 7, Android SDK makes apps trust only CA certificates contained within system certificate store. It can be overrided so that applications can also trust user installed certificates (https://developer.android.com/training/articles/security-config#TrustingAdditionalCas). I saw that PowerTunnel already has an xml file in res/xml/ but it is not attributed in AndroidManifest.xml file hence I fixed it.